### PR TITLE
Catch error when no user is set on request

### DIFF
--- a/hq_superset/hq_domain.py
+++ b/hq_superset/hq_domain.py
@@ -34,8 +34,11 @@ DOMAIN_EXCLUDED_VIEWS = [
 
 
 def is_user_admin():
-    from superset import security_manager
-    return security_manager.is_admin()
+    try:
+        from superset import security_manager
+        return security_manager.is_admin()
+    except AttributeError:
+        return False
 
 
 def ensure_domain_selected():


### PR DESCRIPTION
When trying to access `https://commcare-analytics-staging.dimagi.com/` the server responds with a `500`. The logs show the error at the bottom.

The issue seems to be the fact that `security_manager.is_admin()` doesn't handle no user being set on the request. This PR is really only to catch this error and return `False`. I'm not sure why this wasn't picked up before. 

```
Traceback (most recent call last):
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/flask/app.py", line 1482, in full_dispatch_request
    rv = self.preprocess_request()
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/flask/app.py", line 1974, in preprocess_request
    rv = self.ensure_sync(before_func)()
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/hq_superset/hq_domain.py", line 7, in before_request_hook
    return ensure_domain_selected()
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/hq_superset/hq_domain.py", line 44, in ensure_domain_selected
    if is_user_admin() or (
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/hq_superset/hq_domain.py", line 38, in is_user_admin
    return security_manager.is_admin()
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/superset/security/manager.py", line 2340, in is_admin
    role.name for role in self.get_user_roles()
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/superset/security/manager.py", line 2025, in get_user_roles
    if user.is_anonymous:
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/werkzeug/local.py", line 311, in __get__
    obj = instance._get_current_object()
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/werkzeug/local.py", line 515, in _get_current_object
    return get_name(local())  # type: ignore
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/flask_login/utils.py", line 25, in <lambda>
    current_user = LocalProxy(lambda: _get_user())
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/flask_login/utils.py", line 370, in _get_user
    current_app.login_manager._load_user()
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/flask_login/login_manager.py", line 364, in _load_user
    user = self._user_callback(user_id)
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/flask_appbuilder/security/manager.py", line 2158, in load_user
    if user.is_active:
AttributeError: 'NoneType' object has no attribute 'is_active'
```