### PR TITLE
Delete downloaded files in case of exception as well

### DIFF
--- a/hq_superset/services.py
+++ b/hq_superset/services.py
@@ -68,7 +68,10 @@ def refresh_hq_datasource(
 ):
     """
     Pulls the data from CommCare HQ and creates/replaces the
-    corresponding Superset dataset
+    corresponding Superset dataset.
+
+    The file on the file path passed is not removed and
+    should be done outside this function.
     """
     # See `CsvToDatabaseView.form_post()` in
     # https://github.com/apache/superset/blob/master/superset/views/database/views.py

--- a/hq_superset/tasks.py
+++ b/hq_superset/tasks.py
@@ -12,4 +12,6 @@ def refresh_hq_datasource_task(domain, datasource_id, display_name, export_path,
     except Exception:
         AsyncImportHelper(domain, datasource_id).mark_as_complete()
         raise
-    os.remove(export_path)
+    finally:
+        if os.path.exists(export_path):
+            os.remove(export_path)

--- a/hq_superset/views.py
+++ b/hq_superset/views.py
@@ -127,10 +127,18 @@ def trigger_datasource_refresh(domain, datasource_id, display_name):
     path, size = download_and_subscribe_to_datasource(domain, datasource_id)
     datasource_defn = get_datasource_defn(domain, datasource_id)
     if size < ASYNC_DATASOURCE_IMPORT_LIMIT_IN_BYTES:
-        refresh_hq_datasource(
-            domain, datasource_id, display_name, path, datasource_defn, None
-        )
-        os.remove(path)
+        try:
+            refresh_hq_datasource(
+                domain, datasource_id, display_name, path, datasource_defn, None
+            )
+        except Exception:
+            flash(
+                "The datasource refresh failed. "
+                "Please try again or report if issue persists.",
+                "danger",
+            )
+        finally:
+            os.remove(path)
         return redirect("/tablemodelview/list/")
     else:
         limit_in_mb = int(ASYNC_DATASOURCE_IMPORT_LIMIT_IN_BYTES / 1000000)


### PR DESCRIPTION
https://dimagi.atlassian.net/browse/SC-3646

We were retaining files in case the task fails.

Also reached out to @sravfeyn to confirm this change does not cause unexpected issues [here](https://github.com/dimagi/commcare-analytics/pull/28/files#r1618328156)

The other [place](https://github.com/dimagi/commcare-analytics/blob/bd46e6e7d590879c7934224d2d729227c5fe0b04/hq_superset/services.py#L155) mentioned in the [ticket](https://dimagi.atlassian.net/browse/SC-3646?focusedCommentId=328631) should be handled by this change itself because the exception raised is caught in `refresh_hq_datasource_task` after that.