### PR TITLE
Allow TIMESTAMP values to be None or empty

### DIFF
--- a/hq_superset/utils.py
+++ b/hq_superset/utils.py
@@ -241,8 +241,12 @@ def js_to_py_datetime(jsdt, preserve_tz=True):
     datetime.datetime(2024, 2, 24, 14, 1, 25, 397469, tzinfo=datetime.timezone.utc)
     >>> js_to_py_datetime(jsdt, preserve_tz=False)
     datetime.datetime(2024, 2, 24, 14, 1, 25, 397469)
+    >>> js_to_py_datetime(None) is None
+    True
 
     """
+    if jsdt is None or jsdt == '':
+        return None
     if preserve_tz:
         if sys.version_info >= (3, 11):
             return datetime.fromisoformat(jsdt)


### PR DESCRIPTION
Avoids an error caused when trying to cast `None` as a Python datetime. This can happen when a data source has a null value in a datetime/TIMESTAMP column.

This change is covered by doctests.
