### PR TITLE
Unsubscribe data source on dataset delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,4 @@ tests/.superset/
 superset_config.py
 shared_dir/
 *superset.db
+.idea

--- a/hq_superset/hq_url.py
+++ b/hq_superset/hq_url.py
@@ -23,3 +23,10 @@ def datasource_subscribe(domain, datasource_id):
         f"a/{domain}/configurable_reports/data_sources/subscribe/"
         f"{datasource_id}/"
     )
+
+
+def datasource_unsubscribe(domain, datasource_id):
+    return (
+        f"a/{domain}/configurable_reports/data_sources/unsubscribe/"
+        f"{datasource_id}/"
+    )

--- a/hq_superset/services.py
+++ b/hq_superset/services.py
@@ -196,9 +196,11 @@ def subscribe_to_hq_datasource(domain, datasource_id):
 
 
 def unsubscribe_from_hq_datasource(domain, datasource_id):
-    client = _get_or_create_oauth2client(domain)
-    hq_request = HQRequest(url=datasource_unsubscribe(domain, datasource_id))
+    client = _get_oauth2client(domain)
+    if not client:
+        return
 
+    hq_request = HQRequest(url=datasource_unsubscribe(domain, datasource_id))
     response = hq_request.post({
         'client_id': client.client_id,
     })
@@ -225,8 +227,12 @@ def _get_url_scheme():
     return scheme
 
 
+def _get_oauth2client(domain):
+    return db.session.query(OAuth2Client).filter_by(domain=domain).first()
+
+
 def _get_or_create_oauth2client(domain):
-    client = db.session.query(OAuth2Client).filter_by(domain=domain).first()
+    client = _get_oauth2client(domain)
     if client:
         return client
 

--- a/hq_superset/services.py
+++ b/hq_superset/services.py
@@ -43,7 +43,14 @@ def download_and_subscribe_to_datasource(domain, datasource_id):
         raise HQAPIException("Error downloading the UCR export from HQ")
 
     filename = f"{datasource_id}_{datetime.now()}.zip"
-    path = os.path.join(superset.config.SHARED_DIR, filename)
+
+    directory = superset.config.SHARED_DIR
+    path = os.path.join(directory, filename)
+
+    # Ensure the directory exists
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
     with open(path, "wb") as f:
         f.write(response.content)
 

--- a/hq_superset/services.py
+++ b/hq_superset/services.py
@@ -15,7 +15,12 @@ from superset.sql_parse import Table
 
 from .exceptions import HQAPIException
 from .hq_requests import HQRequest
-from .hq_url import datasource_details, datasource_export, datasource_subscribe
+from .hq_url import (
+    datasource_details,
+    datasource_export,
+    datasource_subscribe,
+    datasource_unsubscribe,
+)
 from .models import OAuth2Client
 from .utils import (
     convert_to_array,
@@ -187,6 +192,25 @@ def subscribe_to_hq_datasource(domain, datasource_id):
     if response.status_code >= 500:
         logger.exception(
             f"Failed to subscribe to data source {datasource_id} due to a remote server error"
+        )
+
+
+def unsubscribe_from_hq_datasource(domain, datasource_id):
+    client = _get_or_create_oauth2client(domain)
+    hq_request = HQRequest(url=datasource_unsubscribe(domain, datasource_id))
+
+    response = hq_request.post({
+        'client_id': client.client_id,
+    })
+    if response.status_code == 200:
+        return
+    if response.status_code < 500:
+        logger.error(
+            f"Failed to unsubscribe from data source {datasource_id} due to the following issue: {response.data}"
+        )
+    if response.status_code >= 500:
+        logger.exception(
+            f"Failed to unsubscribe from data source {datasource_id} due to a remote server error"
         )
 
 

--- a/hq_superset/tests/test_views.py
+++ b/hq_superset/tests/test_views.py
@@ -340,8 +340,9 @@ class TestViews(HQDBTestCase):
             self.assertEqual(size, len(pickle.dumps(TEST_UCR_CSV_V1)))
         os.remove(path)
 
+    @patch('hq_superset.services.unsubscribe_from_hq_datasource')
     @patch('hq_superset.hq_requests.get_valid_cchq_oauth_token', return_value={})
-    def test_refresh_hq_datasource(self, *args):
+    def test_refresh_hq_datasource(self, unsubscribe_mock, *args):
         from hq_superset.services import refresh_hq_datasource
 
         ucr_id = self.oauth_mock.test1_datasources['objects'][0]['id']
@@ -388,5 +389,7 @@ class TestViews(HQDBTestCase):
             _id = datasets['result'][0]['id']
             response = client.get(f'/hq_datasource/delete/{_id}')
             self.assertEqual(response.status, "302 FOUND")
+            unsubscribe_mock.assert_called()
+
             client.get('/hq_datasource/list/', follow_redirects=True)
             self.assert_context('ucr_id_to_pks', {})

--- a/hq_superset/views.py
+++ b/hq_superset/views.py
@@ -53,10 +53,11 @@ class HQDatasourceView(BaseSupersetView):
         return {table.table_name: table.id for table in tables.all()}
 
     def _ucr_id_from_pk(self, datasource_pk):
+        datasource_pk_int = int(datasource_pk)
         # The table name is the UCR datasource id
         try:
             return next(
-                (ds_name for ds_name, ds_pk in self._ucr_id_to_pks().items() if ds_pk == datasource_pk)
+                (ds_name for ds_name, ds_pk in self._ucr_id_to_pks().items() if ds_pk == datasource_pk_int)
             )
         except StopIteration:
             return None


### PR DESCRIPTION
[Ticket](https://dimagi.atlassian.net/browse/SC-3772)

This PR implements the final step to unsubscribe a data source from sending updates to a CCA instance when a user removes a data source on CCA.