### PR TITLE
Make data source update async

### DIFF
--- a/hq_superset/api.py
+++ b/hq_superset/api.py
@@ -60,16 +60,19 @@ class DataSetChangeAPI(BaseApi):
 
         try:
             request_json = json.loads(request.get_data(as_text=True))
-            change = DataSetChange(**request_json)
-            change.update_dataset()
-            return json_success('Dataset updated')
         except json.JSONDecodeError:
             return json_error_response(
                 'Invalid JSON syntax',
                 status=HTTPStatus.BAD_REQUEST.value,
             )
+
+        try:
+            change = DataSetChange(**request_json)
+            change.update_dataset()
         except TableMissing:
             return json_error_response(
                 'Data source not found',
                 status=HTTPStatus.HTTP_404_NOT_FOUND.value,
             )
+        else:
+            return json_success('Dataset updated')

--- a/hq_superset/api.py
+++ b/hq_superset/api.py
@@ -11,6 +11,7 @@ from superset.views.base import (
     json_success,
 )
 
+from .models import DataSetChange
 from .oauth2_server import authorization, require_oauth
 from .tasks import process_dataset_change
 
@@ -62,6 +63,15 @@ class DataSetChangeAPI(BaseApi):
         except json.JSONDecodeError:
             return json_error_response(
                 'Invalid JSON syntax',
+                status=HTTPStatus.BAD_REQUEST.value,
+            )
+
+        try:
+            # ensure change request is parsable
+            DataSetChange(**request_json)
+        except:
+            return json_error_response(
+                'Could not parse change request',
                 status=HTTPStatus.BAD_REQUEST.value,
             )
 

--- a/hq_superset/api.py
+++ b/hq_superset/api.py
@@ -76,4 +76,7 @@ class DataSetChangeAPI(BaseApi):
             )
 
         process_dataset_change.delay(request_json)
-        return json_success('Dataset change accepted')
+        return json_success(
+            'Dataset change accepted',
+            status=HTTPStatus.ACCEPTED.value,
+        )

--- a/hq_superset/tasks.py
+++ b/hq_superset/tasks.py
@@ -2,6 +2,8 @@ import os
 
 from superset.extensions import celery_app
 
+from .exceptions import TableMissing
+from .models import DataSetChange
 from .services import AsyncImportHelper, refresh_hq_datasource
 
 
@@ -15,3 +17,12 @@ def refresh_hq_datasource_task(domain, datasource_id, display_name, export_path,
     finally:
         if os.path.exists(export_path):
             os.remove(export_path)
+
+
+@celery_app.task(name='process_dataset_change')
+def process_dataset_change(request_json):
+    change = DataSetChange(**request_json)
+    try:
+        change.update_dataset()
+    except TableMissing:
+        pass


### PR DESCRIPTION
In order to make the update dataset request as fast as possible so it can keep up with the load of requests received from HQ, move the actual update to a background task via celery