### PR TITLE
Skip revoking tokens

### DIFF
--- a/hq_superset/models.py
+++ b/hq_superset/models.py
@@ -1,4 +1,3 @@
-import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -7,7 +6,6 @@ from authlib.integrations.sqla_oauth2 import (
     OAuth2TokenMixin,
 )
 from cryptography.fernet import MultiFernet
-from sqlalchemy import update
 from superset import db
 
 from .const import OAUTH2_DATABASE_NAME
@@ -77,17 +75,6 @@ class OAuth2Client(db.Model, OAuth2ClientMixin):
 
     def check_client_secret(self, plaintext):
         return self.get_client_secret() == plaintext
-
-    def revoke_tokens(self):
-        revoked_at = int(time.time())
-        stmt = (
-            update(OAuth2Token)
-            .where(OAuth2Token.client_id == self.client_id)
-            .where(OAuth2Token.access_token_revoked_at == 0)
-            .values(access_token_revoked_at=revoked_at)
-        )
-        db.session.execute(stmt)
-        db.session.commit()
 
 
 class OAuth2Token(db.Model, OAuth2TokenMixin):

--- a/hq_superset/oauth2_server.py
+++ b/hq_superset/oauth2_server.py
@@ -41,7 +41,7 @@ require_oauth = ResourceProtector()
 def config_oauth2(app):
     authlib_logger = logging.getLogger('authlib')
     authlib_logger.addHandler(logging.StreamHandler(sys.stdout))
-    authlib_logger.setLevel(logging.DEBUG)
+    authlib_logger.setLevel(logging.INFO)
 
     authorization.init_app(app)
     authorization.register_grant(grants.ClientCredentialsGrant)

--- a/hq_superset/oauth2_server.py
+++ b/hq_superset/oauth2_server.py
@@ -19,12 +19,13 @@ from .models import OAuth2Client, OAuth2Token, db
 def save_token(token: dict, request: FlaskOAuth2Request) -> None:
     client = request.client
 
+    one_day = 24 * 60 * 60
     token = OAuth2Token(
         client_id=client.client_id,
         token_type=token['token_type'],
         access_token=token['access_token'],
         scope=client.domain,
-        expires_in=0,  # Token does not expire
+        expires_in=one_day,
     )
     db.session.add(token)
     db.session.commit()

--- a/hq_superset/oauth2_server.py
+++ b/hq_superset/oauth2_server.py
@@ -18,7 +18,6 @@ from .models import OAuth2Client, OAuth2Token, db
 
 def save_token(token: dict, request: FlaskOAuth2Request) -> None:
     client = request.client
-    client.revoke_tokens()
 
     token = OAuth2Token(
         client_id=client.client_id,

--- a/hq_superset/oauth2_server.py
+++ b/hq_superset/oauth2_server.py
@@ -19,13 +19,12 @@ from .models import OAuth2Client, OAuth2Token, db
 def save_token(token: dict, request: FlaskOAuth2Request) -> None:
     client = request.client
 
-    one_day = 24 * 60 * 60
     token = OAuth2Token(
         client_id=client.client_id,
         token_type=token['token_type'],
         access_token=token['access_token'],
         scope=client.domain,
-        expires_in=one_day,
+        expires_in=10, # 10 Seconds
     )
     db.session.add(token)
     db.session.commit()


### PR DESCRIPTION
Each time a CommCareHQ repeater sends a request to CCA, it requests a new token.
On CCA, when we were generating a new token, we would revoke all old ones for that client.

In case of concurrent requests by repeaters one new token revokes the other one yet to be used, which lead to authorization errors.
So,
we are skipping revoking tokens when generating new tokens.
The expiry time was removed as a part of this investigation and is now added back but with a much shorter time of 10 seconds.

As a follow up, 
we will clean up expired tokens via a celery task and/or not need to get a new token for each repeat record.