### PR TITLE
Add superset command to subscribe to data source changes on HQ

### DIFF
--- a/hq_superset/README.md
+++ b/hq_superset/README.md
@@ -1,0 +1,30 @@
+Notes
+=================
+
+Custom commands 
+---------------
+We can create custom commands to do various ad hoc tasks on the server.
+
+### Adding new commands
+To add a new command you must add it as a nested function inside the `register_commands`
+function in the `__init__.py` file. 
+
+The command can be added as follows:
+```python
+@app.cli.command('<my-command-name>')
+@click.argument('<arg1>')
+def my_custom_command(arg1):
+    ...
+```
+Breakdown of what's happening:
+1. `@app.cli.command`: This registers the command to the app. The command name specified here is used
+to invoke the command from the CLI.
+2. `@click.argument`: This registers any arguments and is optional. 
+
+That's it!
+
+### Running custom commands
+Assuming you have a command registered as `my-custom-command`, you can simply invoke it as follows from the CLI:
+```bash
+superset my-custom-command <arg1_value>
+```

--- a/hq_superset/__init__.py
+++ b/hq_superset/__init__.py
@@ -60,7 +60,7 @@ def register_commands(app):
     @click.argument("data_sources_file_path")
     @click.argument("username")
     @click.argument("apikey")
-    def subscribe_all_data_sources(superset_base_url, hq_base_url, data_sources_file_path, username, apikey):
+    def subscribe_data_sources(superset_base_url, hq_base_url, data_sources_file_path, username, apikey):
         """
         This command takes all data sources in the data_sources_file_path and subscribe to their changes on HQ.
 

--- a/hq_superset/commands.py
+++ b/hq_superset/commands.py
@@ -24,7 +24,9 @@ def subscribe_data_sources(superset_base_url, hq_base_url, data_sources_file_pat
 
     failed_data_sources_by_id = {}
     for domain, datasource_ids in data_sources_by_domain().items():
+        print(f"Handling domain: {domain}")
         for datasource_id in datasource_ids:
+            print(f"Syncing datasource: {datasource_id}")
             client = _get_or_create_oauth2client(domain)
 
             endpoint = datasource_subscribe(domain, datasource_id)

--- a/hq_superset/commands.py
+++ b/hq_superset/commands.py
@@ -1,0 +1,51 @@
+import requests
+import json
+
+
+def subscribe_data_sources(superset_base_url, hq_base_url, data_sources_file_path, username, apikey):
+    from hq_superset.services import (
+        _get_or_create_oauth2client,
+        datasource_subscribe,
+    )
+
+    def data_sources_by_domain():
+        with open(data_sources_file_path) as file:
+            datasource_ids_by_domain = json.loads(file.read())
+
+        # Validate file content
+        assert isinstance(datasource_ids_by_domain, dict)
+        for domain, ds_ids in datasource_ids_by_domain.items():
+            if not isinstance(ds_ids, list):
+                raise Exception(f"{domain} expected a list of data source IDs")
+        return datasource_ids_by_domain
+
+    webhook_url = f"{superset_base_url}/change/"
+    token_url = f"{superset_base_url}/token"
+
+    failed_data_source_ids = {}
+    for domain, datasource_ids in data_sources_by_domain().items():
+        for datasource_id in datasource_ids:
+            client = _get_or_create_oauth2client(domain)
+
+            endpoint = datasource_subscribe(domain, datasource_id)
+            data = {
+                'webhook_url': webhook_url,
+                'token_url': token_url,
+                'client_id': client.client_id,
+                'client_secret': client.get_client_secret(),
+            }
+            response = requests.post(
+                f"{hq_base_url}/{endpoint}",
+                data=data,
+                headers={
+                    "Authorization": f"ApiKey {username}:{apikey}"
+                }
+            )
+
+            if response.status_code != 201:
+                failed_data_source_ids[datasource_id] = response.content
+
+    print("Done!")
+    if failed_data_source_ids:
+        print("The following data sources failed to subscribe")
+        print(failed_data_source_ids)


### PR DESCRIPTION
[Ticket](https://dimagi.atlassian.net/browse/SC-3910)

As part of the linked ticket it's necessary to trigger a (re)subscribe of the data sources on CCA with that on HQ. I've written a flask command to handle this task, so we can reuse this in the future if needed.

#### Approach
  I've decided to make the command reusable for various contexts, so we're now able to define the domain and data sources which needs subscribing in a normal text file on the server and let the command read from that to perform the necessary tasks. I think this approach would be most extensible in the long run, but I'm open to any other suggestions.
 