### PR TITLE
Store expiry correctly

### DIFF
--- a/hq_superset/oauth2_server.py
+++ b/hq_superset/oauth2_server.py
@@ -24,7 +24,7 @@ def save_token(token: dict, request: FlaskOAuth2Request) -> None:
         token_type=token['token_type'],
         access_token=token['access_token'],
         scope=client.domain,
-        expires_in=10, # 10 Seconds
+        expires_in=token['expires_in']
     )
     db.session.add(token)
     db.session.commit()

--- a/superset_config.example.py
+++ b/superset_config.example.py
@@ -63,6 +63,12 @@ OAUTH_PROVIDERS = [
     }
 ]
 
+# override expiry time for a specific grant type by
+# setting this config
+OAUTH2_TOKEN_EXPIRES_IN = {
+    # 'client_credentials': 3600  # seconds
+}
+
 # Will allow user self registration, allowing to create Flask users from
 # Authorized User
 AUTH_USER_REGISTRATION = True


### PR DESCRIPTION
This turns out to be the core of the issue/misunderstanding that we have been seeing.

When we modified the value for [expiry to 0](https://github.com/dimagi/commcare-analytics/commit/d860f896d566e335967bccafdad52b5363cdec6c) it didn't really take effect.
The token that was sent back in response to HQ, is the one that was passed to the function `save_token` and is expected to be stored as it is, though we were modifying it here which would lead to a mismatch in what HQ was told about the token and what we stored. So, a token even if valid according to HQ could be expired as per CommCareAnalytics or vice versa.
This didn't cause any mismatch back then because it set the default value of 1 day which was also the value set for expiry for the token. And HQ was requesting a new token for every request anyway.

But then we modified it to 0 or [10](https://github.com/dimagi/commcare-analytics/commit/e76743c1e972db2c773986791c87e0194a2a2000) which was different from what HQ had for the token.
So, when HQ was updated to reuse token [here](https://github.com/dimagi/commcare-hq/pull/35080), it would get a 401 instead when we modified the value for token expiry to anything other than 1 day, and it was set to 10 seconds recently.

I have added an example of how to correctly override the expiry time.

We can consider adding back revoking tokens, https://github.com/dimagi/commcare-analytics/commit/4c73ffd45200a43326a72795e15e7530eb349196