### PR TITLE
Revert revisit token revocation

### DIFF
--- a/hq_superset/models.py
+++ b/hq_superset/models.py
@@ -1,3 +1,4 @@
+import time
 from dataclasses import dataclass
 from typing import Any
 
@@ -6,6 +7,7 @@ from authlib.integrations.sqla_oauth2 import (
     OAuth2TokenMixin,
 )
 from cryptography.fernet import MultiFernet
+from sqlalchemy import update
 from superset import db
 
 from .const import OAUTH2_DATABASE_NAME
@@ -75,6 +77,17 @@ class OAuth2Client(db.Model, OAuth2ClientMixin):
 
     def check_client_secret(self, plaintext):
         return self.get_client_secret() == plaintext
+
+    def revoke_tokens(self):
+        revoked_at = int(time.time())
+        stmt = (
+            update(OAuth2Token)
+            .where(OAuth2Token.client_id == self.client_id)
+            .where(OAuth2Token.access_token_revoked_at == 0)
+            .values(access_token_revoked_at=revoked_at)
+        )
+        db.session.execute(stmt)
+        db.session.commit()
 
 
 class OAuth2Token(db.Model, OAuth2TokenMixin):

--- a/hq_superset/oauth2_server.py
+++ b/hq_superset/oauth2_server.py
@@ -18,6 +18,7 @@ from .models import OAuth2Client, OAuth2Token, db
 
 def save_token(token: dict, request: FlaskOAuth2Request) -> None:
     client = request.client
+    client.revoke_tokens()
 
     token = OAuth2Token(
         client_id=client.client_id,

--- a/hq_superset/tasks.py
+++ b/hq_superset/tasks.py
@@ -1,9 +1,10 @@
 import os
 
 from superset.extensions import celery_app
+from sqlalchemy import delete
 
 from .exceptions import TableMissing
-from .models import DataSetChange
+from .models import DataSetChange, OAuth2Token, db
 from .services import AsyncImportHelper, refresh_hq_datasource
 
 
@@ -26,3 +27,13 @@ def process_dataset_change(request_json):
         change.update_dataset()
     except TableMissing:
         pass
+
+
+# ToDo: schedule this to run once every week/day
+def delete_revoked_tokens():
+    stmt = (
+        delete(OAuth2Token)
+        .where(OAuth2Token.access_token_revoked_at != 0)
+    )
+    db.session.execute(stmt)
+    db.session.commit()


### PR DESCRIPTION
This PR reverts https://github.com/dimagi/commcare-analytics/pull/56 and takes it a step further with a periodic task to clean up revoked tokens.

Once, https://github.com/dimagi/commcare-analytics/pull/62 is rolled out completely, we should be able to add this PR.
Deleting revoked tokens is to just keep DB light but not critical