### PR TITLE
Upgrade dimagi superset version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     packages=find_packages(exclude=['docs', 'tests']),
     include_package_data=True,
     install_requires=[
-        'dimagi-superset==3.1.0',
+        'dimagi-superset==3.1.0.post1',
         # Dependencies based on Superset 3.1.0 where applicable
         'Authlib==1.3.0',
         'celery==5.2.7',


### PR DESCRIPTION
Simply upgrades dimagi superset version to the latest `3.1.0.post1`.

This new version includes the new ivory-cost country map that was included in [this PR](https://github.com/dimagi/superset/pull/2).