### PR TITLE
Rebuild staging branches script

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,15 @@ The test runner can only run tests that do not import from Superset. The
 code you want to test will need to be in a module whose dependencies
 don't include Superset.
 
+### Testing on staging
+In order to test your feature branch on staging you need to
+1. Check out to `master` branch (make sure it's up to date)
+2. Add your feature branch to the `branches` section in `scripts/staging.yml` file
+3. Push the file back to remote `master`
+4. Run `scripts/rebuildstaging` (this will rebuild the staging branch on your machine)
+5. Push the new `staging` branch to remote
+6. Deploy `staging` as usual
+
 
 ### Creating a migration
 

--- a/scripts/rebuildstaging
+++ b/scripts/rebuildstaging
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+function rebuildstaging() {
+    echo "Rebuilding staging branch..."
+    git-build-branch scripts/staging.yml
+}
+
+rebuildstaging

--- a/scripts/staging.yml
+++ b/scripts/staging.yml
@@ -1,0 +1,10 @@
+# This file is used to keep track of which feature branches
+# should be in the `staging` branch.
+# How it works:
+# 1. Add your feature branch to the end of the list
+# 2. Run ./scripts/rebuildstaging to rebuild the `staging` branch
+# 3. Push the `staging` branch and deploy the code (this is a manual process at the moment)
+trunk: master
+name: staging
+branches:
+  - cs/SC-3473-user-roles-from-hq

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,11 @@ setup(
         'Werkzeug==2.3.3',
         'WTForms==2.3.3',
     ],
+    extras_require={
+        'dev': [
+            'git-build-branch',
+        ],
+    },
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.9'


### PR DESCRIPTION
This PR adds the ability for developers to more easily track and rebuild the CommCare Analytics staging branch. At the moment it's _very_ basic.

### What's the process?
When you have a feature branch that you want to deploy to staging you should first add it to the `scripts/staging.yml` file under the `branches` section and run the command to rebuild the staging branch:
> ./scripts/rebuildstaging

Note that this will only rebuild the staging branch locally, so afterwards you need to push the staging branch and deploy CCA as we currently do - manually. 

### How does it work?
Dimagi maintains a pypi package called [git-rebuild-branch](https://pypi.org/project/git-build-branch/) which this PR is also using. This PR lists it as a dev dependency in the `setup.py` file, so in order to use it the developer must first run
> pip install -e .[dev]

Furthermore, a `rebuildingstaging` bash script simply invokes the command, which in turns pulls the `trunk` (in this case `master` branch) and merge all the listed feature branches into it. All this happens on your local machine of course.
