### PR TITLE
Assign gamma permissions to user domain role

### DIFF
--- a/hq_superset/tests/test_utils.py
+++ b/hq_superset/tests/test_utils.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 from hq_superset.utils import get_column_dtypes, DomainSyncUtil
 from .base_test import SupersetTestCase
 from .const import TEST_DATASOURCE
+from hq_superset.const import GAMMA_ROLE
 
 
 def test_get_column_dtypes():
@@ -28,10 +29,16 @@ def test_doctests():
 
 
 class TestDomainSyncUtil(SupersetTestCase):
-    PLATFORM_ROLE_NAMES = ["Gamma", "sql_lab", "dataset_editor"]
+    PLATFORM_ROLE_NAMES = ["sql_lab", "dataset_editor"]
 
+    @patch.object(DomainSyncUtil, "_domain_user_role_name")
     @patch.object(DomainSyncUtil, "_get_domain_access")
-    def test_gamma_role_assigned_for_edit_permissions(self, get_domain_access_mock):
+    def test_gamma_role_assigned_for_edit_permissions(self, get_domain_access_mock, domain_user_role_name_mock):
+        self._ensure_gamma_role_exists()
+
+        domain_user_role_name = "test-domain_user_1"
+        domain_user_role_name_mock.return_value = domain_user_role_name
+
         security_manager = self.app.appbuilder.sm
         self._ensure_platform_roles_exist(security_manager)
 
@@ -42,10 +49,19 @@ class TestDomainSyncUtil(SupersetTestCase):
         )
         additional_roles = DomainSyncUtil(security_manager)._get_additional_user_roles("test-domain")
         assert len(additional_roles) == 1
-        assert additional_roles[0].name == "Gamma"
+        new_role = additional_roles[0]
 
+        assert new_role.name == domain_user_role_name
+        gamma_role = security_manager.find_role(GAMMA_ROLE)
+        assert gamma_role.permissions == new_role.permissions
+
+
+    @patch.object(DomainSyncUtil, "_domain_user_role_name")
     @patch.object(DomainSyncUtil, "_get_domain_access")
-    def test_no_roles_assigned_without_at_least_read_permission(self, get_domain_access_mock):
+    def test_no_roles_assigned_without_at_least_read_permission(self, get_domain_access_mock, domain_user_role_name_mock):
+        domain_user_role_name = "test-domain_user_1"
+        domain_user_role_name_mock.return_value = domain_user_role_name
+
         security_manager = self.app.appbuilder.sm
         self._ensure_platform_roles_exist(security_manager)
 
@@ -60,7 +76,7 @@ class TestDomainSyncUtil(SupersetTestCase):
     @patch.object(DomainSyncUtil, "_domain_user_role_name")
     @patch.object(DomainSyncUtil, "_get_domain_access")
     def test_read_permission_gives_custom_domain_role(self, get_domain_access_mock, domain_user_role_name_mock):
-        domain_user_role_name = "test-domain_user_1_read_only"
+        domain_user_role_name = "test-domain_user_1"
         domain_user_role_name_mock.return_value = domain_user_role_name
 
         security_manager = self.app.appbuilder.sm
@@ -74,11 +90,12 @@ class TestDomainSyncUtil(SupersetTestCase):
         additional_roles = DomainSyncUtil(security_manager)._get_additional_user_roles("test-domain")
         assert len(additional_roles) == 1
         assert additional_roles[0].name == domain_user_role_name
+        assert additional_roles[0].permissions
 
     @patch.object(DomainSyncUtil, "_domain_user_role_name")
     @patch.object(DomainSyncUtil, "_get_domain_access")
     def test_permissions_change_updates_user_role(self, get_domain_access_mock, domain_user_role_name_mock):
-        domain_user_role_name = "test-domain_user_1_read_only"
+        domain_user_role_name = "test-domain_user_1"
         domain_user_role_name_mock.return_value = domain_user_role_name
 
         security_manager = self.app.appbuilder.sm
@@ -112,3 +129,17 @@ class TestDomainSyncUtil(SupersetTestCase):
             "can_write": can_write,
             "can_read": can_read,
         }, roles
+
+    def _ensure_gamma_role_exists(self):
+        """
+        This method mocks the gamma role if one does not exist
+        """
+        security_manager = self.app.appbuilder.sm
+        gamma_role = security_manager.find_role(GAMMA_ROLE)
+
+        if not gamma_role:
+            gamma_role = security_manager.add_role(GAMMA_ROLE)
+            permission = security_manager.add_permission_view_menu(
+                "can_write", "dashboard",
+            )
+            security_manager.add_permission_role(gamma_role, permission)


### PR DESCRIPTION
This PR is an alternative approach (see [this comment](https://github.com/dimagi/commcare-analytics/pull/59#discussion_r1825585233)) to how we assign "edit" permissions to a user on CCA. 

**Please comment on the preferred approach.**

### Glossary
`domain user role` -> the role assigned to a user on a domain which governs the user's permissions on the domain.

### What's changed?
The previous PR does the following:
1. For any view-only users we create a `domain user role` and give that role all the view-only permissions
2. For an edit user we don't create a new `domain user role` but rather give the standard `Gamma` role (we **don't** assign both the `domain user role` and the `Gamma` role since the `Gamma` role already has all the view permissions)
3. If a view-only user is upgraded to an edit user we need to make sure to clean up the redundant `domain user role` in the DB. 

This PR, however, does it this way:
1. For any user on the domain we create the `domain user role` regardless of what their permission level is. This role will be updated with the necessary permissions as is defined on HQ (view/edit)
2. If the user has only view access it works the same as the previous PR in that we only assign view permissions to the role
3. If the user has edit access we simply look at the `Gamma` role's permissions and assign those permissions to the role
4. If a view-only user is upgraded to an edit user we don't need any role clean-up, since the permissions is overwritten on the role itself.

The main difference between this PR and the previous one is that instead of assigning or unassigning the `Gamma` role / `domain user role` we assign the `Gamma` role permissions (or view-only permissions, depending on HQ configuration) always only to the **one role** (`domain user role`) which we use to manage the user's permissions. 
