### PR TITLE
Only store errors results

### DIFF
--- a/hq_superset/tasks.py
+++ b/hq_superset/tasks.py
@@ -19,7 +19,7 @@ def refresh_hq_datasource_task(domain, datasource_id, display_name, export_path,
             os.remove(export_path)
 
 
-@celery_app.task(name='process_dataset_change')
+@celery_app.task(name='process_dataset_change', ignore_result=True, store_errors_even_if_ignored=True)
 def process_dataset_change(request_json):
     change = DataSetChange(**request_json)
     try:


### PR DESCRIPTION
Minor change to skip storing results for the task "process_dataset_change" if its succeeded.

Settings can be found here
1. https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-ignore-result
2. https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-store-errors-even-if-ignored

the naming is without the "task-" when passed through the decorator.