### PR TITLE
Remove missing task

### DIFF
--- a/superset_config.example.py
+++ b/superset_config.example.py
@@ -130,10 +130,11 @@ class CeleryConfig:
         },
     }
     beat_schedule = {
-        'email_reports.schedule_hourly': {
-            'task': 'email_reports.schedule_hourly',
-            'schedule': crontab(minute='1', hour='*'),
-        },
+        # example:
+        # 'email_reports.schedule_hourly': {
+        #     'task': 'email_reports.schedule_hourly',
+        #     'schedule': crontab(minute='1', hour='*'),
+        # }
     }
 
 


### PR DESCRIPTION
It appears this task was either never there or now removed

from celery logs
```
Thw full contents of the message headers:
{'lang': 'py', 'task': 'email_reports.schedule_hourly', 'id': '2fd27c9c-ab86-46e9-b87d-a99d34a5b6aa', 'shadow': None, 'eta': N
one, 'expires': None, 'group': None, 'group_index': None, 'retries': 0, 'timelimit': [None, None], 'root_id': '2fd27c9c-ab86-4
6e9-b87d-a99d34a5b6aa', 'parent_id': None, 'argsrepr': '()', 'kwargsrepr': '{}', 'origin': 'gen648994@ip-172-31-38-75', 'ignor
e_result': False}

The delivery info for this task is:
{'exchange': '', 'routing_key': 'celery'}
Traceback (most recent call last):
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/celery/worker/consumer/consumer.py", line 591, in 
on_task_received
    strategy = strategies[type_]
KeyError: 'email_reports.schedule_hourly'
[2024-09-19 05:01:00,058: INFO/Beat] Scheduler: Sending due task email_reports.schedule_hourly (email_reports.schedule_hourly)
[2024-09-19 05:01:00,065: ERROR/MainProcess] Received unregistered task of type 'email_reports.schedule_hourly'.
The message has been ignored and discarded.

Did you remember to import the module containing this task?
Or maybe you're using relative imports?
```

Additionally, its not in the tasks recognized by celery (from logs on celery startup)
```
[tasks]
  . cache-warmup
  . cache_chart_thumbnail
  . cache_dashboard_thumbnail
  . fetch_url
  . process_dataset_change
  . refresh_hq_datasource_task
  . reports.execute
  . reports.prune_log
  . reports.scheduler
  . sql_lab.get_sql_results
```