### PR TITLE
Fix database name

### DIFF
--- a/superset_config.example.py
+++ b/superset_config.example.py
@@ -43,7 +43,7 @@ SQLALCHEMY_BINDS = {
     OAUTH2_DATABASE_NAME: 'postgresql://postgres:postgres@localhost:5432/superset_oauth2'
 }
 
-HQ_DATABASE_URI = "postgresql://commcarehq:commcarehq@localhost:5432/superset_hq_data"
+HQ_DATABASE_URI = "postgresql://commcarehq:commcarehq@localhost:5432/superset_cchq_data"
 
 # Populate with oauth credentials from your local CommCareHQ
 OAUTH_PROVIDERS = [


### PR DESCRIPTION
CommCare Ansible specifies [this database name](https://github.com/dimagi/commcare-analytics-ansible/blob/9e4216dcb2003072d901effa805243996e9cc2b9/environments/example/vars.yml#L12), so this PR is simply to rectify this repo's take on it.