### PR TITLE
Redirect user to login page when oauth session expired

### DIFF
--- a/hq_superset/__init__.py
+++ b/hq_superset/__init__.py
@@ -8,8 +8,8 @@ def flask_app_mutator(app):
     # Import the views (which assumes the app is initialized) here
     # return
     from superset.extensions import appbuilder
-
     from . import api, hq_domain, oauth2_server, views
+    from .exceptions import OAuthSessionExpired
 
     appbuilder.add_view(views.HQDatasourceView, 'Update HQ Datasource', menu_cond=lambda *_: False)
     appbuilder.add_view(views.SelectDomainView, 'Select a Domain', menu_cond=lambda *_: False)
@@ -17,6 +17,7 @@ def flask_app_mutator(app):
     appbuilder.add_api(api.DataSetChangeAPI)
     oauth2_server.config_oauth2(app)
 
+    app.register_error_handler(OAuthSessionExpired, hq_domain.oauth_session_expired)
     app.before_request(hq_domain.before_request_hook)
     app.after_request(hq_domain.after_request_hook)
     app.strict_slashes = False

--- a/hq_superset/hq_domain.py
+++ b/hq_superset/hq_domain.py
@@ -2,6 +2,7 @@ from datetime import timedelta
 
 import superset
 from flask import current_app, flash, g, redirect, request, session, url_for
+from flask_login import logout_user
 from superset.config import USER_DOMAIN_ROLE_EXPIRY
 from superset.extensions import cache_manager
 
@@ -37,6 +38,15 @@ def after_request_hook(response):
     if request.url_rule and (request.url_rule.endpoint in logout_views):
         response.set_cookie('hq_domain', '', expires=0)
     return response
+
+
+def oauth_session_expired(*arg, **kwargs):
+    logout_user()
+    flash(
+        f"Your session has expired. Please log in again.",
+        'warning',
+    )
+    return redirect(url_for("AuthOAuthView.login"))
 
 
 DOMAIN_EXCLUDED_VIEWS = [

--- a/hq_superset/oauth.py
+++ b/hq_superset/oauth.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 import superset
+from authlib.integrations.base_client import OAuthError
 from flask import flash, session
 from requests.exceptions import HTTPError
 from superset.security import SupersetSecurityManager
@@ -101,7 +102,7 @@ def refresh_and_fetch_token(refresh_token):
             refresh_token=refresh_token
         )
         return refresh_response
-    except HTTPError:
+    except (HTTPError, OAuthError):
         # If the refresh token too expired raise exception.
         raise OAuthSessionExpired(
             "OAuth refresh token has expired. User need to re-authorize the OAuth Application"


### PR DESCRIPTION
[Ticket](https://dimagi.atlassian.net/browse/SC-4105)

We've been having an issue on CCA where users which are already logged in to CCA could not access the site due to a 500 error. The error can be seen below.

>  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/hq_superset/utils.py", line 220, in _get_domain_access
    response = hq_request.get()
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/hq_superset/hq_requests.py", line 28, in get
    return self.commcare_provider.get(self.url, token=self.oauth_token)
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/hq_superset/hq_requests.py", line 13, in oauth_token
    return get_valid_cchq_oauth_token()
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/hq_superset/oauth.py", line 91, in get_valid_cchq_oauth_token
    refresh_response = refresh_and_fetch_token(refresh_token)
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/hq_superset/oauth.py", line 99, in refresh_and_fetch_token
    refresh_response = provider._get_oauth_client().refresh_token(
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/authlib/oauth2/client.py", line 256, in refresh_token
    return self._refresh_token(
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/authlib/oauth2/client.py", line 377, in _refresh_token
    token = self.parse_response_token(resp)
  File "/home/ubuntu/www/.virtualenvs/superset/lib/python3.10/site-packages/authlib/oauth2/client.py", line 344, in parse_response_token
    raise self.oauth_error_class(
authlib.integrations.base_client.errors.OAuthError: invalid_grant: 

This was likely due to the [refresh token having expired](https://stackoverflow.com/questions/26724003/using-refresh-token-exception-error-invalid-grant/38434442#38434442).

This PR simply adds a way of catching the `OAuthSessionExpired` if it's raised in any of the views and does the following:
1. Log out the current user
2. Redirect that user to the login page asking the user to log in back again.

A simple test has been added to test this behaviour. 