### PR TITLE
Register missing task

### DIFF
--- a/hq_superset/tasks.py
+++ b/hq_superset/tasks.py
@@ -30,6 +30,7 @@ def process_dataset_change(request_json):
         pass
 
 
+@celery_app.task(name='delete_redundant_shared_files')
 def delete_redundant_shared_files():
     """
     Delete shared temporary files older than REMOVE_SHARED_FILES_AFTER days

--- a/superset_config.example.py
+++ b/superset_config.example.py
@@ -140,7 +140,7 @@ class CeleryConfig:
         #     'schedule': crontab(minute='1', hour='*'),
         # }
         'delete_redundant_shared_files': {
-            'task': 'tasks.delete_redundant_shared_files',
+            'task': 'delete_redundant_shared_files',
             'schedule': crontab(hour='0', minute='0')
         }
     }


### PR DESCRIPTION
As a follow up to https://github.com/dimagi/commcare-analytics/pull/90,
Register the task so it is discovered by celery

Tested
```
[2024-12-16 08:01:00,043: INFO/MainProcess] Task delete_redundant_shared_files[850a0b75-2d85-4760-a5cd-df77dc51baff] received
[2024-12-16 08:01:00,046: INFO/ForkPoolWorker-6] Task delete_redundant_shared_files[850a0b75-2d85-4760-a5cd-df77dc51baff] succeeded in 0.002176055684685707s: None
```