### PR TITLE
Remove Branch from staging.yml

### DIFF
--- a/scripts/staging.yml
+++ b/scripts/staging.yml
@@ -7,4 +7,3 @@
 trunk: master
 name: staging
 branches:
-  - ze/dd-celery-integration


### PR DESCRIPTION
Simply removes a branch from the `staging.yml` file which is no longer needed.