### PR TITLE
Fix order in staging.yml

### DIFF
--- a/scripts/staging.yml
+++ b/scripts/staging.yml
@@ -7,6 +7,6 @@
 trunk: master
 name: staging
 branches:
+  - nh/test_maps+cs/SC-4106-add-dd-application-monitoring
   - cs/SC-4106-add-dd-application-monitoring
   - nh/test_maps
-  - nh/test_maps+cs/SC-4106-add-dd-application-monitoring


### PR DESCRIPTION
No rush on this one, because I lost patience and rebuilt the staging branch manually. :expressionless: 

But I was an idiot, and put the merge branch _after_ the conflicting branches, instead of _before_ them. This PR has the correct order.

I'm opening the PR so that `staging.yml` in master is an accurate reflection of what is deployed.
