### PR TITLE
Support multiple doc_ids

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,10 +9,10 @@ jobs:
 
   tests:
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
-        python-version: [3.9, '3.10', 3.11]
+        python-version: ['3.9', '3.10', '3.11']
     env:
       PYTHONPATH: ${{ github.workspace }}
     services:
@@ -49,6 +49,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
+          pip install setuptools
           pip install --no-cache-dir -e '.[test]'
       - name: Create shared_dir
         run: |

--- a/hq_superset/models.py
+++ b/hq_superset/models.py
@@ -34,7 +34,7 @@ class DataSetChange:
     data_source_id: str
     doc_id: str
     data: list[dict[str, Any]]
-    doc_ids: Optional[list[str]]
+    doc_ids: Optional[list[str]] = None
 
     def update_dataset(self):
         with statsd.timed('cca.dataset_change.timer', tags=get_tags({"datasource": self.data_source_id})):

--- a/hq_superset/tests/test_api.py
+++ b/hq_superset/tests/test_api.py
@@ -77,8 +77,11 @@ class TestAPI(HQDBTestCase):
 
     def test_post_dataset_change_too_large(self):
         row = {"doc_id": "def123", "foo": "bar"}
+        # To create a payload that is bigger than the 10MB limit, set
+        # "data" to A LOT of rows. To calculate the number of rows we
+        # need, divide 10MB by the size of one row, and add 1:
         row_str = json.dumps(row)
-        num_rows = 10 * 1024 * 1024 // len(row_str) + 1  # > 10MB limit
+        num_rows = 10 * 1024 * 1024 // len(row_str) + 1
         payload = {
             "data_source_id": "abc123",
             "doc_id": "def123",

--- a/hq_superset/tests/test_api.py
+++ b/hq_superset/tests/test_api.py
@@ -1,0 +1,119 @@
+import json
+from contextlib import contextmanager
+from unittest.mock import patch
+
+from hq_superset.tests.base_test import HQDBTestCase
+
+
+class TestAPI(HQDBTestCase):
+
+    def test_post_dataset_change_with_doc_ids(self):
+        payload = {
+            "data_source_id": "abc123",
+            "doc_id": "",
+            "doc_ids": ["def123", "def456"],
+            "data": [
+                {"doc_id": "def123", "foo": "bar"},
+                {"doc_id": "def456", "foo": "bar"}
+            ]
+        }
+        with (
+            patch_oauth_validation(),
+            patch('hq_superset.api.process_dataset_change.delay')
+        ):
+            response = self.client.post(
+                '/commcarehq_dataset/change/',
+                data=json.dumps(payload),
+                content_type='application/json',
+                headers={"Authorization": "Bearer test-token"}
+            )
+        assert response.status_code == 202
+        assert response.text == 'Dataset change accepted'
+
+    def test_post_dataset_change_with_doc_id(self):
+        payload = {
+            "data_source_id": "abc123",
+            "doc_id": "def123",
+            "data": [
+                {"doc_id": "def123", "foo": "bar"}
+            ]
+        }
+        with (
+            patch_oauth_validation(),
+            patch('hq_superset.api.process_dataset_change.delay')
+        ):
+            response = self.client.post(
+                '/commcarehq_dataset/change/',
+                data=json.dumps(payload),
+                content_type='application/json',
+                headers={"Authorization": "Bearer test-token"}
+            )
+        assert response.status_code == 202
+        assert response.text == 'Dataset change accepted'
+
+    def test_post_dataset_change_invalid_format(self):
+        # Missing required fields
+        payload = {"foo": "bar"}
+        with patch_oauth_validation():
+            response = self.client.post(
+                '/commcarehq_dataset/change/',
+                data=json.dumps(payload),
+                content_type='application/json',
+                headers={"Authorization": "Bearer test-token"}
+            )
+        assert response.status_code == 400
+        assert response.json == {'error': 'Could not parse change request'}
+
+    def test_post_dataset_change_invalid_json(self):
+        with patch_oauth_validation():
+            response = self.client.post(
+                '/commcarehq_dataset/change/',
+                data='invalid json',
+                content_type='application/json',
+                headers = {"Authorization": "Bearer test-token"}
+            )
+        assert response.status_code == 400
+        assert response.json == {"error": "Invalid JSON syntax"}
+
+    def test_post_dataset_change_too_large(self):
+        row = {"doc_id": "def123", "foo": "bar"}
+        row_str = json.dumps(row)
+        num_rows = 10 * 1024 * 1024 // len(row_str) + 1  # > 10MB limit
+        payload = {
+            "data_source_id": "abc123",
+            "doc_id": "def123",
+            "data": [row] * num_rows
+        }
+        with patch_oauth_validation():
+            response = self.client.post(
+                '/commcarehq_dataset/change/',
+                data=json.dumps(payload),
+                content_type='application/json',
+                headers={"Authorization": "Bearer test-token"}
+            )
+        assert response.status_code == 413
+        assert response.json == {'error': 'Entity is too large'}
+
+
+@contextmanager
+def patch_oauth_validation():
+
+    class DummyValidator:
+        TOKEN_TYPE = 'bearer'
+        def __call__(self, *a, **kw):
+            return self
+        def validate_request(self, *a, **kw):
+            return True
+        def authenticate_token(self, token_string):
+            class Token: pass
+            return Token()
+        def validate_token(self, token, scopes, request, **kwargs):
+            return True  # Accepts any token
+
+    with patch("hq_superset.oauth2_server.create_bearer_token_validator", return_value=DummyValidator):
+        # Re-register the patched validator with require_oauth
+        from hq_superset import oauth2_server
+        oauth2_server.require_oauth._token_validators.clear()
+        oauth2_server.require_oauth.register_token_validator(DummyValidator())
+
+        yield


### PR DESCRIPTION
Context: [SC-3872](https://dimagi.atlassian.net/browse/SC-3872)

This change accommodates merged payloads from CommCare HQ.

A merged payload uses a "doc _ids" field. It preserves the original schema by leaving the "doc_id" field empty. e.g.
```json
{
  "data_source_id": "abc123",
  "doc_id": "",
  "doc_ids": ["a1", "b2"],
  "data": [
    {"doc_id": "a1", "foo": "bar"},
    {"doc_id": "b2", "foo": "baz"}
  ]
}
```
