### PR TITLE
Update staging branches

### DIFF
--- a/scripts/staging.yml
+++ b/scripts/staging.yml
@@ -8,3 +8,4 @@ trunk: master
 name: staging
 branches:
   - nh/test_maps
+  - cs/SC-4275-add-moz-map


### PR DESCRIPTION
Add branch to staging.yml.

The [feature branch](https://github.com/dimagi/commcare-analytics/compare/cs/SC-4275-add-moz-map?expand=1) will use the latest version of `dimagi/superset`, which has the mozambique country map added.