### PR TITLE
Use new version of dimagi-superset

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     packages=find_packages(exclude=['docs', 'tests']),
     include_package_data=True,
     install_requires=[
-        'dimagi-superset==3.1.0.post1',
+        'dimagi-superset==3.1.0.post2',
         # Dependencies based on Superset 3.1.0 where applicable
         'Authlib==1.3.0',
         'celery==5.2.7',


### PR DESCRIPTION
[Ticket](https://dimagi.atlassian.net/browse/SC-4275)

An new version of dimagi-superset is available with the `mozambique` country map added (see [change here](https://github.com/dimagi/superset/pull/4), although adding the map required me to follow [this guide](https://github.com/dimagi/commcare-analytics/blob/master/apache-superset.md#example-of-adding-a-new-customization), which does not make use of the `master` branch to track changes, but rather github tags - we need to consolidate the two, because it's confusing. [Here is a difference](https://github.com/dimagi/superset/compare/master...dimagi:superset:3.1.0-dimagi-4) between the latest tagged version and `master`).

This PR is to make use of the new version.

Please note that CCA staging already makes use of this new version of dimagi-superset. 

I'm going to ask an AE to QA the changes.