### PR TITLE
Use latest dimagi-superset version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         # Dependencies based on Superset 3.1.0 where applicable
         'Authlib==1.3.0',
         'celery==5.3.6',
-        'cryptography==41.0.2',
+        'cryptography==42.0.4',
         'jinja2==3.1.2',
         'psycopg2==2.9.6',
         'requests==2.31.0',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ setup(
         'dimagi-superset==4.1.1',
         # Dependencies based on Superset 3.1.0 where applicable
         'Authlib==1.3.0',
-        'celery==5.2.7',
+        'celery==5.3.6',
         'cryptography==41.0.2',
         'jinja2==3.1.2',
         'psycopg2==2.9.6',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
     packages=find_packages(exclude=['docs', 'tests']),
     include_package_data=True,
     install_requires=[
-        'dimagi-superset==3.1.0.post2',
+        'dimagi-superset==4.1.1',
         # Dependencies based on Superset 3.1.0 where applicable
         'Authlib==1.3.0',
         'celery==5.2.7',


### PR DESCRIPTION
~~[Ticket](https://dimagi.atlassian.net/browse/SC-4298)~~
Added a [new ticket](https://dimagi.atlassian.net/browse/SC-4322) for this work 

[Version 4.1.1](https://pypi.org/project/dimagi-superset/4.1.1/) of dimagi-superset is available, which is now in sync with [apache-superset](https://github.com/apache/superset). 

This PR makes ensures CCA makes use of this new version.

### Test plan
The upgrade will be deployed and tested extensively on staging to make sure it's working as intended before rolling it out to production.  