### PR TITLE
Error Handling for False-Positive SQLLab Exception

### DIFF
--- a/hq_superset/hq_domain.py
+++ b/hq_superset/hq_domain.py
@@ -63,9 +63,12 @@ def error_check_after_request(response_obj):
             'GENERIC_DB_ENGINE_ERROR',
         ]
         response_dict = json.loads(response.decode('utf-8'))
-        for error in response_dict['errors']:
-            if error['error_type'] in VALID_ERROR_TYPES:
-                return True
+        try:
+            for error in response_dict['errors']:
+                if error['error_type'] in VALID_ERROR_TYPES:
+                    return True
+        except KeyError:
+            pass
         return False
 
     if (

--- a/hq_superset/hq_domain.py
+++ b/hq_superset/hq_domain.py
@@ -57,7 +57,7 @@ def error_check_after_request(response_obj):
     endpoints that return false-positive 500 errors and change them to
     a more appropriate 400 error.
     """
-    def has_valid_errors(response):
+    def should_update_status_code_for_errors(response):
         VALID_ERROR_TYPES = [
             'COLUMN_DOES_NOT_EXIST_ERROR',
             'GENERIC_DB_ENGINE_ERROR',
@@ -71,7 +71,7 @@ def error_check_after_request(response_obj):
     if (
         request.path.startswith("/api/v1/sqllab/execute/")
         and response_obj.status_code == 500
-        and has_valid_errors(response_obj.response[0])
+        and should_update_status_code_for_errors(response_obj.response[0])
     ):
         response_obj.status_code = 400
     return response_obj

--- a/hq_superset/hq_domain.py
+++ b/hq_superset/hq_domain.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+import json
 
 import superset
 from flask import current_app, flash, g, redirect, request, session, url_for
@@ -37,6 +38,7 @@ def after_request_hook(response):
     ]
     if request.url_rule and (request.url_rule.endpoint in logout_views):
         response.set_cookie('hq_domain', '', expires=0)
+    response = error_check_after_request(response)
     return response
 
 
@@ -47,6 +49,32 @@ def oauth_session_expired(*arg, **kwargs):
         'warning',
     )
     return redirect(url_for("AuthOAuthView.login"))
+
+
+def error_check_after_request(response_obj):
+    """
+    This gets used by the Flask app's after_request hook to check for
+    endpoints that return false-positive 500 errors and change them to
+    a more appropriate 400 error.
+    """
+    def has_valid_errors(response):
+        VALID_ERROR_TYPES = [
+            'COLUMN_DOES_NOT_EXIST_ERROR',
+            'GENERIC_DB_ENGINE_ERROR',
+        ]
+        response_dict = json.loads(response.decode('utf-8'))
+        for error in response_dict['errors']:
+            if error['error_type'] in VALID_ERROR_TYPES:
+                return True
+        return False
+
+    if (
+        request.path.startswith("/api/v1/sqllab/execute/")
+        and response_obj.status_code == 500
+        and has_valid_errors(response_obj.response[0])
+    ):
+        response_obj.status_code = 400
+    return response_obj
 
 
 DOMAIN_EXCLUDED_VIEWS = [

--- a/superset_config.example.py
+++ b/superset_config.example.py
@@ -193,6 +193,8 @@ TALISMAN_CONFIG = {
 USER_DOMAIN_ROLE_EXPIRY = 60 # minutes
 SKIP_DATASET_CHANGE_FOR_DOMAINS = []
 
+from flask import Response
+
 SERVER_ENVIRONMENT = 'changeme'  # staging, production, etc.
 
 def FLASK_APP_MUTATOR(app: Flask):
@@ -206,7 +208,7 @@ def error_check_after_req(response_obj):
     """
     if (
         request.path.startswith("/api/v1/sqllab/execute/")
-        and response_obj.status == "500 INTERNAL SERVER ERROR"
+        and response_obj.status_code == 500
     ):
-        response_obj.status = 400
+        response_obj.status_code = 400    
     return response_obj

--- a/superset_config.example.py
+++ b/superset_config.example.py
@@ -193,8 +193,6 @@ TALISMAN_CONFIG = {
 USER_DOMAIN_ROLE_EXPIRY = 60 # minutes
 SKIP_DATASET_CHANGE_FOR_DOMAINS = []
 
-from flask import Response
-
 SERVER_ENVIRONMENT = 'changeme'  # staging, production, etc.
 
 def FLASK_APP_MUTATOR(app: Flask):

--- a/superset_config.example.py
+++ b/superset_config.example.py
@@ -9,7 +9,6 @@
 import sentry_sdk
 from cachelib.redis import RedisCache
 from celery.schedules import crontab
-from flask import Flask, request
 from flask_appbuilder.security.manager import AUTH_DB, AUTH_OAUTH
 from sentry_sdk.integrations.flask import FlaskIntegration
 
@@ -194,19 +193,3 @@ USER_DOMAIN_ROLE_EXPIRY = 60 # minutes
 SKIP_DATASET_CHANGE_FOR_DOMAINS = []
 
 SERVER_ENVIRONMENT = 'changeme'  # staging, production, etc.
-
-def FLASK_APP_MUTATOR(app: Flask):
-    app.after_request(error_check_after_req)
-
-def error_check_after_req(response_obj):
-    """
-    This gets used by the Flask app's after_request hook to check for
-    endpoints that return false-positive 500 errors and change them to
-    a more appropriate 400 error.
-    """
-    if (
-        request.path.startswith("/api/v1/sqllab/execute/")
-        and response_obj.status_code == 500
-    ):
-        response_obj.status_code = 400    
-    return response_obj

--- a/superset_config.example.py
+++ b/superset_config.example.py
@@ -9,6 +9,7 @@
 import sentry_sdk
 from cachelib.redis import RedisCache
 from celery.schedules import crontab
+from flask import Flask, request
 from flask_appbuilder.security.manager import AUTH_DB, AUTH_OAUTH
 from sentry_sdk.integrations.flask import FlaskIntegration
 
@@ -193,3 +194,19 @@ USER_DOMAIN_ROLE_EXPIRY = 60 # minutes
 SKIP_DATASET_CHANGE_FOR_DOMAINS = []
 
 SERVER_ENVIRONMENT = 'changeme'  # staging, production, etc.
+
+def FLASK_APP_MUTATOR(app: Flask):
+    app.after_request(error_check_after_req)
+
+def error_check_after_req(response_obj):
+    """
+    This gets used by the Flask app's after_request hook to check for
+    endpoints that return false-positive 500 errors and change them to
+    a more appropriate 400 error.
+    """
+    if (
+        request.path.startswith("/api/v1/sqllab/execute/")
+        and response_obj.status == "500 INTERNAL SERVER ERROR"
+    ):
+        response_obj.status = 400
+    return response_obj


### PR DESCRIPTION
Link to ticket [here](https://dimagi.atlassian.net/browse/SC-4284).

This PR introduces a small change in which an extra check is added to the `after_request` handler for the Superset Flask application. This new hook essentially checks for 500 requests coming in from the `/api/v1/sqllab/execute/` endpoint which have a certain error type and changes them to 400.

The reason for this change is that SQLLab allows for creating invalid queries (e.g. accessing a table that doesn't exist). When this happens, Superset simply throws an unhandled 500 exception which then gets raised as a false-positive 500 request on Datadog. Changing the status code to 400 more appropriately flags it as simply an invalid request rather than an exception.

From a user's perspective nothing is changing and they will still see the same error message on the front-end:
![Screenshot from 2025-03-13 15-42-31](https://github.com/user-attachments/assets/7adf966a-0d2c-42f0-86b5-f4d84c3d9e69)

But the logs will now reflect the error as a 400 instead of a 500:
![2025-03-13_15-42](https://github.com/user-attachments/assets/22b3c4a4-aacc-4255-bc2a-e6a1baf3c946)

~~Please note, that there exists a related PR in the commcare-analytics-ansible repo to add the same to the superset_config file for an Ansible deploy. The PR can be accessed [here](https://github.com/dimagi/commcare-analytics-ansible/pull/54).~~